### PR TITLE
Handle Promise rejection properly

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -18,18 +18,16 @@ const defaultWorkConfig = (): WorkConfig => ({
     },
 });
 
-async function getConfigFile(
-    configPath: string,
-): Promise<Record<string, unknown>> {
-    try {
-        return Bun.file(configPath).json();
-    } catch (err) {
-        if (err instanceof SyntaxError) {
-            console.error("Failed to read config, using defaults");
-        }
-        // no config found, use default
-        return {};
-    }
+function getConfigFile(configPath: string): Promise<Record<string, unknown>> {
+    return Bun.file(configPath)
+        .json()
+        .catch((err: unknown) => {
+            if (err instanceof SyntaxError) {
+                console.error("Failed to read config, using defaults");
+            }
+            // no config found, use default
+            return {};
+        });
 }
 
 export async function loadConfig(): Promise<WorkConfig> {


### PR DESCRIPTION
The previous version of this function returned a Promise that was not awaited in a try block, so when the Promise rejected, the try block did not catch it, resulting in a ENOENT when the error should have been recovered.

I've used the .catch method of the Promise instead as I think it's more readable than using the try/catch construct in this case.

Resolves #4